### PR TITLE
Let response sender return an `Attempt<SideEffect>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Requires `innmind/filesystem:~8.0`
 - Requires `innmind/time-continuum:~4.1`
 - Requires `innmind/io:~3.0`
+- `Innmind\Http\Sender::__invoke()` now returns `Innmind\Immutable\Attempt<Innmind\Immutable\SideEffect>`
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "~8.2",
         "innmind/url": "~4.0",
-        "innmind/immutable": "~5.7",
+        "innmind/immutable": "~5.11",
         "innmind/filesystem": "~8.0",
         "innmind/io": "^3.0.1",
         "innmind/time-continuum": "~4.1",

--- a/src/ResponseSender.php
+++ b/src/ResponseSender.php
@@ -12,6 +12,10 @@ use Innmind\Http\{
     Exception\LogicException,
 };
 use Innmind\TimeContinuum\Clock;
+use Innmind\Immutable\{
+    Attempt,
+    SideEffect,
+};
 
 final class ResponseSender implements Sender
 {
@@ -23,10 +27,10 @@ final class ResponseSender implements Sender
     }
 
     #[\Override]
-    public function __invoke(Response $response): void
+    public function __invoke(Response $response): Attempt
     {
         if (\headers_sent()) {
-            throw new LogicException('Headers already sent');
+            return Attempt::error(new LogicException('Headers already sent'));
         }
 
         \header(
@@ -69,6 +73,8 @@ final class ResponseSender implements Sender
         if (\function_exists('fastcgi_finish_request')) {
             fastcgi_finish_request();
         }
+
+        return Attempt::result(SideEffect::identity());
     }
 
     private function sendCookie(SetCookie $cookie): void

--- a/src/Sender.php
+++ b/src/Sender.php
@@ -3,7 +3,15 @@ declare(strict_types = 1);
 
 namespace Innmind\Http;
 
+use Innmind\Immutable\{
+    Attempt,
+    SideEffect,
+};
+
 interface Sender
 {
-    public function __invoke(Response $response): void;
+    /**
+     * @return Attempt<SideEffect>
+     */
+    public function __invoke(Response $response): Attempt;
 }


### PR DESCRIPTION
This will allow code relying on `Sender` to better handle errors and allow for lazy execution.